### PR TITLE
removed violet blue from bad word list

### DIFF
--- a/config/matchlists/mccormick.txt
+++ b/config/matchlists/mccormick.txt
@@ -322,7 +322,6 @@ urophilia
 vagina
 venus mound
 vibrator
-violet blue
 violet wand
 vorarephilia
 voyeur


### PR DESCRIPTION
It's a person's name, and not a vulgar phrase.
