### PR TITLE
Make regex ending slightly smarter

### DIFF
--- a/lib/language_filter.rb
+++ b/lib/language_filter.rb
@@ -277,7 +277,7 @@ module LanguageFilter
       if @creative_letters then
         CREATIVE_END_REGEX
       else
-        '\\b'
+        '(?=\b|\s|$)'
       end
     end
   end


### PR DESCRIPTION
So we can match match words ending with chars that do not constitute
words boundaries like

    stigm@

Closes #5